### PR TITLE
Update build process to use pnpm pack

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,8 +15,9 @@ jobs:
       run: corepack enable && pnpm install
     - name: Build project
       run: pnpm run build
-    - name: Upload artifact
-      uses: actions/upload-artifact@v4
+    - name: Pack and Upload artifact
+      run: pnpm pack
+    - uses: actions/upload-artifact@v4
       with:
-        name: dist
-        path: dist/
+        name: package
+        path: "*.tgz"

--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+  "name": "ci-parallelizer",
   "dependencies": {
     "@(-.-)/env": "^0.3.2",
     "@aws-sdk/client-dynamodb": "^3.525.0",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "ci-parallelizer",
+  "version": "0.0.0-0",
   "dependencies": {
     "@(-.-)/env": "^0.3.2",
     "@aws-sdk/client-dynamodb": "^3.525.0",


### PR DESCRIPTION
Updates the package configuration and build workflow to align with new artifact handling requirements.

- Adds the name "ci-parallelizer" to `package.json` to clearly identify the package.
- Modifies the `.github/workflows/build.yml` to run `pnpm pack` after building the project, changing the artifact upload process to include the generated `.tgz` file instead of the `dist/` directory.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/dtinth/parallelizer?shareId=2413a313-6a8a-4b8a-8469-f37d747848c3).